### PR TITLE
Support tmux versions that do not have the -l flag

### DIFF
--- a/lib/layout-helpers.sh
+++ b/lib/layout-helpers.sh
@@ -68,7 +68,12 @@ select_pane() {
 #   - $2: (optional) Target pane ID to run command in.
 #
 run_cmd() {
-  tmux send-keys -t "$session:$window.$2" -l "$1"
+  literal_support=$(tmux send-keys -l 2&> /dev/null ; echo $?)
+  if [ $literal_support -eq 0 ]; then
+    tmux send-keys -t "$session:$window.$2" -l "$1"
+  else
+    tmux send-keys -t "$session:$window.$2" "$1"
+  fi
   tmux send-keys -t "$session:$window.$2" "C-m"
 }
 


### PR DESCRIPTION
This supports my tmux version, which is the lastest homebrew will
install and does not have the -l flag on the send-keys command
