### PR TITLE
When specifying a windows default path, rvm no longer works

### DIFF
--- a/lib/layout-helpers.sh
+++ b/lib/layout-helpers.sh
@@ -17,8 +17,8 @@ new_window() {
   if [ -n "$2" ]; then local command=("$2"); fi
   if [ -n "$window" ]; then local winarg=(-n "$window"); fi
 
-  if [ -n "$window_root" ]; then cd "$window_root"; fi
   tmux new-window -t "$session:" "${winarg[@]}" "${command[@]}"
+  __goto_window_or_session_path
 }
 
 # Split current window/pane vertically.
@@ -30,6 +30,7 @@ new_window() {
 split_v() {
   if [ -n "$1" ]; then local percentage=(-p "$1"); fi
   tmux split-window -t "$session:$window.$2" -v "${percentage[@]}"
+  __goto_window_or_session_path
 }
 
 # Split current window/pane horizontally.
@@ -41,6 +42,7 @@ split_v() {
 split_h() {
   if [ -n "$1" ]; then local percentage=(-p "$1"); fi
   tmux split-window -t "$session:$window.$2" -h "${percentage[@]}"
+  __goto_window_or_session_path
 }
 
 # Select a specific window.
@@ -232,5 +234,13 @@ __go_to_session() {
     tmux -u attach-session -t "$session:"
   else
     tmux -u switch-client -t "$session:"
+  fi
+}
+
+__goto_window_or_session_path() {
+  local window_or_session_root=${window_root-$session_root}
+  if [ -n "$window_or_session_root" ]; then
+    run_cmd "cd \"$window_or_session_root\""
+    send_keys "C-l"
   fi
 }


### PR DESCRIPTION
Specifying the windows default path does not execute a cd in the shell when the window/pane is opened so the `.rvmrc` is not sourced and my `run_cmd` commands that need a specific rvm config do not work.

I will work on fixing this as soon as I can, but if someone has some good ideas on how to fix this or has time to thought I would make it known.
