### PR TITLE
tmux set-option default-path

### DIFF
--- a/lib/layout-helpers.sh
+++ b/lib/layout-helpers.sh
@@ -84,7 +84,7 @@ run_cmd() {
   send_keys "C-m" "$2"
 }
 
-# Cusomize session root path. Default is `$HOME`.
+# Customize session root path. Default is `$HOME`.
 #
 # Arguments:
 #   - $1: Directory path to use for session root.


### PR DESCRIPTION
I'd like to use session_root but I don't want tmuxifier to change default-path option of my tmux session (it's set to "" so new splits/windows inherit working directory).
Thus I added small option to control this behavior.
