### PR TITLE
Add optional window name when loading windows

### DIFF
--- a/lib/layout-helpers.sh
+++ b/lib/layout-helpers.sh
@@ -144,11 +144,16 @@ window_root() {
 #
 # Arguments:
 #   - $1: Name of window layout to load.
+#   - $2: Override default window name.
 #
 load_window() {
   local file="$TMUXIFIER_LAYOUT_PATH/$1.window.sh"
   if [ -f "$file" ]; then
-    window="$1"
+    if [ $# -gt 1 ]; then
+      window="$2"
+    else
+      window="$1"
+    fi
     source "$file"
     window=
 


### PR DESCRIPTION
This turns windows into templates making them reusable in the same or multiple sessions.
When creating windows I omit both the window_root and the name on new window. Now I can create multiples of these and have them named what I want them. I also call window_root prior to load_window.

```
session_root "~/work/projects/MASSIVE_APP"
if initialize_session "MASSIVE_APP"; then
  window_root "./module_1"
  load_window "dev" "mod1"
  window_root "./module_2"
  load_window "dev" "mod2" 
  window_root "./module_3"
  load_window "dev" "mod3"
  select_window 1
fi
finalize_and_go_to_session
```

Example Window

```
new_window
split_v 50
split_h 50
run_cmd "vim ." 1
run_cmd "grunt watch" 2
run_cmd "git status" 3
select_pane  1
```
