### PR TITLE
Allow renaming windows from within the layout files

### DIFF
--- a/lib/layout-helpers.sh
+++ b/lib/layout-helpers.sh
@@ -21,6 +21,17 @@ new_window() {
   __go_to_window_or_session_path
 }
 
+# Rename the chosen window.
+#
+# Arguments:
+#   - $1: Window to be renamed
+#   - $2: New name to the chosen window
+#   - $3: (optional) Seconds to delay the renaming
+rename_window() {
+  if [ -z "$3" ]; then local seconds=5; fi
+  ( sleep "$seconds" 2>/dev/null; tmux rename-window -t "$session:$1" "$2" ) &
+}
+
 # Split current window/pane vertically.
 #
 # Arguments:

--- a/lib/layout-helpers.sh
+++ b/lib/layout-helpers.sh
@@ -22,14 +22,25 @@ new_window() {
 }
 
 # Rename the chosen window.
+# Has to be called from a layout.session.sh file.
 #
 # Arguments:
 #   - $1: Window to be renamed
 #   - $2: New name to the chosen window
-#   - $3: (optional) Seconds to delay the renaming
-rename_window() {
-  if [ -z "$3" ]; then local seconds=5; fi
-  ( sleep "$seconds" 2>/dev/null; tmux rename-window -t "$session:$1" "$2" ) &
+#   - $3: (optional) Seconds to delay the renaming (default 3)
+rename_window_from_session() {
+  __rename_window $1 $2 $3
+}
+
+# Rename the chosen window.
+# Has to be called from a layout.window.sh file.
+#
+# Arguments:
+#   - $1: New name to the chosen window
+#   - $2: (optional) Seconds to delay the renaming (default 3)
+rename_window_from_window() {
+  __get_active_window_id
+  __rename_window $_window_id $1 $2
 }
 
 # Split current window/pane vertically.
@@ -319,4 +330,22 @@ __go_to_window_or_session_path() {
     run_cmd "cd \"$window_or_session_root\""
     run_cmd "clear"
   fi
+}
+
+__get_active_window_id() {
+  _window_id=$( tmux list-windows | grep active | grep -o "^[0-9]*" )
+}
+
+# Abstraction to rename the window.
+#
+# Arguments:
+#   - $1: Window to be renamed
+#   - $2: New name to the chosen window
+#   - $3: (optional) Seconds to delay the renaming (default 3)
+__rename_window() {
+  local delay=$3
+  if [ -z "$3" ]; then delay=3; fi
+
+  ( sleep "$delay" 2>/dev/null; tmux rename-window -t $1 $2 ) &
+  unset _window_id
 }


### PR DESCRIPTION
Ok, there it is... it's not very clean actually but it does its job.

If you use prezto or another shell framework with some sort of automatic rename of the Tmux title, it normally gets renamed from  `preexec` or `precmd`, which means the title will keep renaming itself, even after you choose a name from `new_window`. Since  the name of the window has to be renamed after everything, the only way I found was to run a subshell and call sleep from there.

Most times you could need this if if you are checking a log (`tail -f` for ie) and you are not likely to use that pane/window again. Running local servers, using guard or tools that are going to be run once could benefit from a renaming after they have been started.

This in the end, allows to use something like:

```shell
# guard.window.sh

new_window
# window get renamed something like .../path/to/where/is/being/run
rename_window_from_window "guard"
```

or
```shell
# my-project.session.sh
# asuming we are inside the if initalize_session....

load_window "vim"
new_window "logs"

# Load a defined window layout.
load_window "guard"

# since it's id will be three
rename_window_from_session 1 "project-file"
rename_window_from_session 3 "guard"

# Select the default active window on session creation.
select_window 1
```

The idea is simply being to be able to rename the window from itself, inside a `layout.window.sh` or from a session `layout.session.sh`.

I couldn't find a way to check if the function was being called from a `layout.session.sh` or `layout.window.sh`, so I had to create two different functions from each, but I'm pretty sure something could be done to improve this, please don't hesitate to comment on how I can improve it.

Well... I hope my explanation was clear =/
