### PR TITLE
Problems with zsh installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ Clone the repo to your machine:
 
     git clone https://github.com/jimeh/tmuxifier.git ~/.tmuxifier
 
-Then add `~/.tmuxifier/bin` to your PATH to make the `tmuxifier` executable
+Then add `$HOME/.tmuxifier/bin` to your PATH to make the `tmuxifier` executable
 available to you:
 
 __In bash & zsh:__
 
 ```bash
-export PATH="./.tmuxifier/bin:$PATH"
+export PATH="$HOME/.tmuxifier/bin:$PATH"
 ```
 
 __In tcsh:__


### PR DESCRIPTION
I cloned your repo under my home and make the bin executable and add the following settings in my `~/.zshrc`

``` bash
export PATH="~/.tmuxifier/bin:$PATH"

if [[ -d "$HOME/bin" ]] ; then
  PATH="$HOME/bin:$PATH"
fi

eval "$(tmuxifier init -)"
```

When reloading the shell I got the following error:

``` bash
/home/wikimatze/.zshrc:155: command not found: tmuxifier
```

The workaround to this issue is get rid of tilde in the export path and give the absolute path:

``` bash
export PATH="$HOME/.tmuxifier/bin:$PATH"
```
