### PR TITLE
Source missing utility functions in tmuxifier-tmux

### DIFF
--- a/libexec/tmuxifier-tmux
+++ b/libexec/tmuxifier-tmux
@@ -2,6 +2,9 @@
 set -e
 [ -n "$TMUXIFIER_DEBUG" ] && set -x
 
+# Load internal utility functions.
+source "$TMUXIFIER/lib/util.sh"
+
 # Provide tmuxifier help
 if calling-help "$@"; then
   echo "usage: tmuxifier tmux [...]


### PR DESCRIPTION
This fixes `~/.tmuxifier/libexec/tmuxifier-tmux: line 6: calling-help: command not found`
