### PR TITLE
Accommodate fish shell 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ __In fish:__
 And add the following to your `~/.config/fish/config.fish` or equivalent:
 
 ```bash
-eval (tmuxifier init -)
+eval (tmuxifier init - fish)
 ```
 
 ### Custom Tmux Arguments

--- a/init.fish
+++ b/init.fish
@@ -11,7 +11,10 @@ end
 # If `tmuxifier` is available, and `$TMUXIFIER_NO_COMPLETE` is not set, then
 # load Tmuxifier shell completion.
 if test -n (which tmuxifier); and test -z $TMUXIFIER_NO_COMPLETE
-  source "$TMUXIFIER/completion/tmuxifier.fish"
+    # fish shell 2.0.0 does not have the source alias
+    if [ (fish --version 2>| awk -F'version ' '{print $2}') = '2.0.0' ];
+      . "$TMUXIFIER/completion/tmuxifier.fish"
+    else
+      source "$TMUXIFIER/completion/tmuxifier.fish"
+    end
 end
-
-

--- a/libexec/tmuxifier-init
+++ b/libexec/tmuxifier-init
@@ -76,7 +76,12 @@ case "$shell" in
     ;;
   fish )
     echo "set -gx TMUXIFIER \"$TMUXIFIER\";"
-    echo "source \"\$TMUXIFIER/init.fish\";"
+    # fish shell 2.0.0 does not have the source alias
+    if [[ $(fish --version 2>&1 | awk -F'version ' '{print $2}') = '2.0.0' ]]; then
+      echo ". \"\$TMUXIFIER/init.fish\";"
+    else
+      echo "source \"\$TMUXIFIER/init.fish\";"
+    fi  
     ;;
   * )
     echo "export TMUXIFIER=\"$TMUXIFIER\";"


### PR DESCRIPTION
Relates to and works around one issue of https://github.com/jimeh/tmuxifier/issues/55 -- fish shell 2.0.0 doesn't appear to have the alias "source."

I don't have a solution for the case of the default shell being bash and detecting the current shell invoked is fish when libexec/tmuxifier-init runs inside bash again. Perhaps there is a way to determine the parent shell?
