### PR TITLE
Work around a problem with tmux has-session:

### DIFF
--- a/lib/layout-helpers.sh
+++ b/lib/layout-helpers.sh
@@ -253,7 +253,7 @@ initialize_session() {
   tmuxifier-tmux start-server
 
   # Check if the named session already exists.
-  if tmuxifier-tmux has-session -t "$session:" 2>/dev/null; then
+  if tmuxifier-tmux list-sessions | grep -q "^$session:"; then
     return 1
   fi
 


### PR DESCRIPTION
tmux has-session does a prefix match and not an exact match.

When a session "ABC" does exist, the session "A" is also interpreted as "ABC"
Using tmux list-sessions fixes this problem
