### PR TITLE
Fix version comparison for git compiled tmux

### DIFF
--- a/libexec/tmuxifier-tmux-version
+++ b/libexec/tmuxifier-tmux-version
@@ -44,7 +44,9 @@ vercomp () {
 version=$(tmux -V)
 version=${version/tmux /}
 
-if [ -n "$1" ]; then
+if [ "$version" = master ]; then
+    echo '>'
+elif [ -n "$1" ]; then
   # Fix for "1.9a" version comparison, as vercomp() can only deal with
   # purely numeric version numbers.
   version=${version//+([a-zA-Z])/}


### PR DESCRIPTION
On tmux compiled from git/svn the output of 'tmux -V' is 'tmux master', which causes the version comparison to fail, prohibiting tmuxifier from starting.