### PR TITLE
specify session in set-option command

### DIFF
--- a/lib/layout-helpers.sh
+++ b/lib/layout-helpers.sh
@@ -24,7 +24,7 @@ new_window() {
   tmuxifier-tmux new-window -t "$session:" "${winarg[@]}" "${command[@]}"
 
   # Disable renaming if a window name was given.
-  if [ -n "$1" ]; then tmuxifier-tmux set-option -t "$1" allow-rename off; fi
+  if [ -n "$1" ]; then tmuxifier-tmux set-option -t "$session:$1" allow-rename off; fi
 
   window="$(__get_current_window_index)"
   __go_to_window_or_session_path


### PR DESCRIPTION
this fixes a bug (#68) where one cannot load a new session inside of a running tmux session