### PR TITLE
fix(layout-helpers): split_h/split_v work correctly on latest tmux

### DIFF
--- a/lib/layout-helpers.sh
+++ b/lib/layout-helpers.sh
@@ -37,7 +37,12 @@ new_window() {
 #   - $2: (optional) Target pane ID to split in current window.
 #
 split_v() {
-  if [ -n "$1" ]; then local percentage=(-p "$1"); fi
+  if [ "$(tmuxifier-tmux-version "3.0")" == ">" ]; then
+    # Tmux 3.1 and later.
+    if [ -n "$1" ]; then local percentage=(-l "$1"'%'); fi
+  else
+    if [ -n "$1" ]; then local percentage=(-p "$1"); fi
+  fi
   tmuxifier-tmux split-window -t "$session:$window.$2" -v "${percentage[@]}"
   __go_to_window_or_session_path
 }
@@ -49,7 +54,12 @@ split_v() {
 #   - $2: (optional) Target pane ID to split in current window.
 #
 split_h() {
-  if [ -n "$1" ]; then local percentage=(-p "$1"); fi
+  if [ "$(tmuxifier-tmux-version "3.0")" == ">" ]; then
+    # Tmux 3.1 and later.
+    if [ -n "$1" ]; then local percentage=(-l "$1"'%'); fi
+  else
+    if [ -n "$1" ]; then local percentage=(-p "$1"); fi
+  fi
   tmuxifier-tmux split-window -t "$session:$window.$2" -h "${percentage[@]}"
   __go_to_window_or_session_path
 }


### PR DESCRIPTION
The `-p` flag on `split-window` was deprecated in Tmux 3.1 in favor of just
adding a `%` suffix to the numeric value given to the `-l` flag.

This uses the new `-l <n>%` format on Tmux 3.1 and later, and uses the old
`-p <n>` format on 3.0 and older.