### PR TITLE
Allow overriding names of new windows and sessions.

### DIFF
--- a/lib/layout-helpers.sh
+++ b/lib/layout-helpers.sh
@@ -19,6 +19,7 @@ tmux() {
 #
 new_window() {
   if [ -n "$1" ]; then local winarg=(-n "$1"); fi
+  if [ -n "$window" ]; then local winarg=(-n "$window"); fi
   if [ -n "$2" ]; then local command=("$2"); fi
 
   tmuxifier-tmux new-window -t "$session:" "${winarg[@]}" "${command[@]}"
@@ -285,7 +286,7 @@ load_session() {
 #   fi
 #
 initialize_session() {
-  if [ -n "$1" ]; then
+  if [ -z "$session" ] && [ -n "$1" ]; then
     session="$1"
   fi
 

--- a/libexec/tmuxifier-load-session
+++ b/libexec/tmuxifier-load-session
@@ -7,7 +7,7 @@ source "$TMUXIFIER/lib/util.sh"
 
 # Provide tmuxifier help
 if calling-help "$@"; then
-  echo "usage: tmuxifier load-session <layout_name | file_path> [<iterm mode>]
+  echo "usage: tmuxifier load-session <layout_name | file_path> [<iterm mode>] [<session name>]
 
 Aliases: session, ses, s
 
@@ -19,7 +19,9 @@ Arguments:
                                 directory, or path to a session layout file.
    <iterm mode>               - When given as \"-CC\" tmux will be called with
                                 the -CC argument enabling iTerm2 integration.
-                                More info: https://iterm2.com"
+                                More info: https://iterm2.com
+   <session name>             - When given, overrides the name of the new session
+                                to be <session name>."
   exit
 fi
 
@@ -37,9 +39,18 @@ fi
 # Load runtime functions.
 source "$TMUXIFIER/lib/runtime.sh"
 
-if [ "$2" == "-CC" ]; then
-  export TMUXIFIER_TMUX_ITERM_ATTACH="-CC"
-fi
+# If -CC is in the argument list, set TMUXIFIER_TMUX_ITERM_ATTACH
+# and then remove the argument from $@.
+for arg
+do
+    shift
+    if test "$arg" = "-CC"
+    then
+        export TMUXIFIER_TMUX_ITERM_ATTACH="-CC"
+        continue
+    fi
+    set -- "$@" "$arg"
+done
 
 # Load session file.
-load_session "$1"
+load_session "$@"

--- a/libexec/tmuxifier-load-window
+++ b/libexec/tmuxifier-load-window
@@ -7,7 +7,7 @@ source "$TMUXIFIER/lib/util.sh"
 
 # Provide tmuxifier help
 if calling-help "$@"; then
-  echo "usage: tmuxifier load-window <layout_name | file_path>
+  echo "usage: tmuxifier load-window <layout_name | file_path> [<window name>]
 
 Aliases: window, win, w
 
@@ -15,7 +15,9 @@ Create a new window using the specified window layout in the current session.
 
 Arguments:
    <layout_name | file_path>  - Name of a window layout stored in the layouts
-                                directory, or path to a window layout file."
+                                directory, or path to a window layout file.
+   <window name>              - When given, overrides the name of the new window
+                                to be <window name>."
   exit
 fi
 
@@ -35,7 +37,7 @@ source "$TMUXIFIER/lib/runtime.sh"
 
 if [ ! -z $TMUX ]; then
   session="$(tmuxifier-current-session)"
-  load_window "$1"
+  load_window "$@"
 else
   echo "tmuxifier: 'load-window' command can only be used from within Tmux."
   exit 1


### PR DESCRIPTION
This changeset modifies `tmuxifier-load-window` and `tmuxifier-load-session` to accept an optional argument that sets the name of the new window or session, overriding the default from the configuration file (or its name).

This also required small changes to the `new_window()` and `initialize_session()` functions in order to respect the `$window` and `$session` variables, respectively, which were already set by the calling `load_window()` and `load_session()` functions, but were ignored.