### PR TITLE
Prepend commands in run_cmd with a space to prevent them to be stored in the history

### DIFF
--- a/lib/layout-helpers.sh
+++ b/lib/layout-helpers.sh
@@ -408,7 +408,7 @@ __go_to_window_or_session_path() {
 
   # local window_or_session_root=${window_root-$session_root}
   if [ -n "$target_path" ]; then
-    run_cmd "cd \"$target_path\""
-    run_cmd "clear"
+    run_cmd " cd \"$target_path\""
+    run_cmd " clear"
   fi
 }


### PR DESCRIPTION
Hello,

First of all, thanks for this tool, it's awesome!

However I have a small issue with the history, in the function `__go_to_window_or_session_path`,  it calls `run_cmd "cd \"$target_path\""` and `run_cmd "clear"`, which get added to my history. I find this a bit annoying since I didn't typed those commands myself. I would appreciate if it would be possible to disable this behavior.

An idea to fix that issue is to prepend those commands with a `<space>` character. If the user has set the variable [`HISTCONTROL=ignorespace`](https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html#index-HISTCONTROL) or `HISTCONTROL=ignoreboth`, the command will be ignored from the history.

In the case some users would want to keep those commands in their history, we could add an environment variable `TMUXIFIER_KEEP_HISTORY`, but I'm not sure that anybody would want that ?