### PR TITLE
fix: specify 'session:window' for set-option command in new_window function

### DIFF
--- a/lib/layout-helpers.sh
+++ b/lib/layout-helpers.sh
@@ -24,7 +24,7 @@ new_window() {
   tmuxifier-tmux new-window -t "$session:" "${winarg[@]}" "${command[@]}"
 
   # Disable renaming if a window name was given.
-  if [ -n "$1" ]; then tmuxifier-tmux set-option -t "$1" allow-rename off; fi
+  if [ -n "$1" ]; then tmuxifier-tmux set-option -t "$session:$1" allow-rename off; fi
 
   window="$(__get_current_window_index)"
   __go_to_window_or_session_path


### PR DESCRIPTION
re: [issue - session can't load window](https://github.com/jimeh/tmuxifier/issues/115)

`tmuxifier load-session $session-layout` loads the windows specified in the layout --> _expected behavior:_

`tmuxifier load-session $session-layout` fails with message "no such window"; _unless loading each window before loading the session_ --> _current behavior_

how to reproduce:
create session layout and create window layout
load session.

looking at debug logs:
it seems like loading the window directly, associates the window to the current session, 
but when loading the session, the window layout is sourced, the `set-option` command needs to specify `$session:$window`

> `tmux set-option -t editor allow-rename off`
> no such window: window-name