### PR TITLE
fix: use exec to eliminate redundant bash wrapper processes

### DIFF
--- a/lib/layout-helpers.sh
+++ b/lib/layout-helpers.sh
@@ -387,10 +387,10 @@ __get_current_window_index() {
 
 __go_to_session() {
   if [ -z "$TMUX" ]; then
-    tmuxifier-tmux $TMUXIFIER_TMUX_ITERM_ATTACH -u \
+    exec tmuxifier-tmux $TMUXIFIER_TMUX_ITERM_ATTACH -u \
       attach-session -t "$session:"
   else
-    tmuxifier-tmux -u switch-client -t "$session:"
+    exec tmuxifier-tmux -u switch-client -t "$session:"
   fi
 }
 

--- a/libexec/tmuxifier-tmux
+++ b/libexec/tmuxifier-tmux
@@ -2,4 +2,4 @@
 set -e
 [ -n "$TMUXIFIER_DEBUG" ] && set -x
 
-tmux $TMUXIFIER_TMUX_OPTS "$@"
+exec tmux $TMUXIFIER_TMUX_OPTS "$@"


### PR DESCRIPTION
Without exec, launching a session leaves two persistent bash processes: tmuxifier-load-session waiting on tmuxifier-tmux, which waits on tmux. With exec, each script replaces itself so only the tmux process remains.

## Problem

Launching a session via `tmuxifier load-session` leaves two persistent bash processes alive for the lifetime of the session:

```text
foot -> bash tmuxifier-load-session
        -> bash tmuxifier-tmux
        -> tmux attach-session
```

`tmuxifier-load-session` waits on `tmuxifier-tmux` which then waits on `tmux`. Both bash processes sit idle consuming memory with no useful work left to do after tmux has finished launching.

## Fix

Use `exec` in two places so each script replaces itself rather than forking a child:

- `libexec/tmuxifier-tmux`: `exec tmux ...` replaces the bash process with tmux directly
- `lib/layout-helpers.sh` `__go_to_session()`: `exec tmuxifier-tmux ...` replaces the `tmuxifier-load-session` process, which then execs into tmux

## Result

Only the `tmux` process remains, no leftover bash wrappers.